### PR TITLE
Ignore the phpunit cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.phpcs-cache
+/.phpunit.cache/
 /.phpunit.result.cache
 /clover.xml
 /coveralls-upload.json


### PR DESCRIPTION
## Summary

Follow-up to the cleanup cycle. The ignore rule only covered `/.phpunit.result.cache` — the **pre-10** filename — while `phpunit.xml.dist` sets `cacheDirectory=".phpunit.cache"`, so the directory phpunit actually writes was unignored.

This repo and `api-tools-provider` were the two done before the gap was spotted; the other thirteen got the rule as part of their cleanup PR. **`provider` needs no equivalent** — no phpunit dependency, no test directory, no `cacheDirectory` setting.

Worth fixing rather than leaving: in `api-tools-api-problem` the same gap had already let `.phpunit.cache/test-results` become a **tracked** file.

No version tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added PHPUnit cache files to the ignored files list, keeping generated test artifacts out of version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->