### PR TITLE
Use test stubs, and give the container mocks a real invocation count

### DIFF
--- a/test/ConfigResourceFactoryTest.php
+++ b/test/ConfigResourceFactoryTest.php
@@ -7,6 +7,7 @@ use Laminas\ApiTools\Configuration\Factory\ConfigResourceFactory;
 use Laminas\Config\Writer\WriterInterface;
 use Override;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
@@ -27,22 +28,22 @@ class ConfigResourceFactoryTest extends TestCase
     private $factory;
 
     /**
-     * @var WriterInterface|MockObject
-     * @psalm-var WriterInterface&MockObject
+     * @var WriterInterface|Stub
+     * @psalm-var WriterInterface&Stub
      */
     private $writer;
 
     #[Override]
     protected function setUp(): void
     {
-        $this->writer    = $this->createMock(WriterInterface::class);
+        $this->writer    = $this->createStub(WriterInterface::class);
         $this->container = $this->createMock(ContainerInterface::class);
         $this->factory   = new ConfigResourceFactory();
     }
 
     public function testReturnsInstanceOfConfigResource(): void
     {
-        $this->container->method('has')->with('config')->willReturn(false);
+        $this->container->expects(self::atLeastOnce())->method('has')->with('config')->willReturn(false);
         $this->container
             ->expects(self::once())
             ->method('get')
@@ -57,7 +58,7 @@ class ConfigResourceFactoryTest extends TestCase
 
     public function testDefaultAttributesValues(): void
     {
-        $this->container->method('has')->with('config')->willReturn(false);
+        $this->container->expects(self::atLeastOnce())->method('has')->with('config')->willReturn(false);
         $this->container
             ->expects(self::once())
             ->method('get')
@@ -81,7 +82,7 @@ class ConfigResourceFactoryTest extends TestCase
             ],
         ];
 
-        $this->container->method('has')->with('config')->willReturn(true);
+        $this->container->expects(self::atLeastOnce())->method('has')->with('config')->willReturn(true);
         $this->container->expects(self::atLeastOnce())->method('get')->willReturnMap([
             ['config', $config],
             [self::WRITER_SERVICE, $this->writer],
@@ -104,7 +105,7 @@ class ConfigResourceFactoryTest extends TestCase
             ],
         ];
 
-        $this->container->method('has')->with('config')->willReturn(true);
+        $this->container->expects(self::atLeastOnce())->method('has')->with('config')->willReturn(true);
         $this->container->expects(self::atLeastOnce())->method('get')->willReturnMap([
             ['config', $config],
             [self::WRITER_SERVICE, $this->writer],

--- a/test/ConfigWriterFactoryTest.php
+++ b/test/ConfigWriterFactoryTest.php
@@ -5,40 +5,34 @@ namespace LaminasTest\ApiTools\Configuration;
 use Laminas\ApiTools\Configuration\Factory\ConfigWriterFactory;
 use Laminas\Config\Writer\PhpArray;
 use Override;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 class ConfigWriterFactoryTest extends TestCase
 {
-    /**
-     * @var ContainerInterface|MockObject
-     * @psalm-var ContainerInterface&MockObject
-     */
-    private $container;
-
     /** @var ConfigWriterFactory */
     private $factory;
 
     #[Override]
     protected function setUp(): void
     {
-        $this->container = $this->createMock(ContainerInterface::class);
-        $this->factory   = new ConfigWriterFactory();
+        $this->factory = new ConfigWriterFactory();
     }
 
     public function testReturnsInstanceOfPhpArrayWriter(): void
     {
+        $container    = $this->createStub(ContainerInterface::class);
         $factory      = $this->factory;
-        $configWriter = $factory($this->container);
+        $configWriter = $factory($container);
 
         $this->assertInstanceOf(PhpArray::class, $configWriter);
     }
 
     public function testDefaultFlagsValues(): void
     {
+        $container    = $this->createStub(ContainerInterface::class);
         $factory      = $this->factory;
-        $configWriter = $factory($this->container);
+        $configWriter = $factory($container);
 
         $this->assertObjectHasProperty('useBracketArraySyntax', $configWriter);
         $this->assertFalse($configWriter->getUseClassNameScalars());
@@ -46,30 +40,32 @@ class ConfigWriterFactoryTest extends TestCase
 
     public function testEnableShortArrayFlagIsSet(): void
     {
-        $this->container->method('has')->with('config')->willReturn(true);
-        $this->container->expects(self::atLeastOnce())->method('get')->with('config')->willReturn([
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects(self::atLeastOnce())->method('has')->with('config')->willReturn(true);
+        $container->expects(self::atLeastOnce())->method('get')->with('config')->willReturn([
             'api-tools-configuration' => [
                 'enable_short_array' => true,
             ],
         ]);
 
         $factory      = $this->factory;
-        $configWriter = $factory($this->container);
+        $configWriter = $factory($container);
 
         $this->assertObjectHasProperty('useBracketArraySyntax', $configWriter);
     }
 
     public function testClassNameScalarsFlagIsSet(): void
     {
-        $this->container->method('has')->with('config')->willReturn(true);
-        $this->container->expects(self::atLeastOnce())->method('get')->with('config')->willReturn([
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects(self::atLeastOnce())->method('has')->with('config')->willReturn(true);
+        $container->expects(self::atLeastOnce())->method('get')->with('config')->willReturn([
             'api-tools-configuration' => [
                 'class_name_scalars' => true,
             ],
         ]);
 
         $factory      = $this->factory;
-        $configWriter = $factory($this->container);
+        $configWriter = $factory($container);
 
         $this->assertTrue($configWriter->getUseClassNameScalars());
     }

--- a/test/ResourceFactoryTest.php
+++ b/test/ResourceFactoryTest.php
@@ -20,7 +20,7 @@ class ResourceFactoryTest extends TestCase
     protected function setUp(): void
     {
         $this->resourceFactory = new ResourceFactory(
-            $this->createMock(ModuleUtils::class),
+            $this->createStub(ModuleUtils::class),
             $this->testWriter  = new TestAsset\ConfigWriter()
         );
     }


### PR DESCRIPTION
## Summary

Part of the **mock-to-stub pass**. **No version tag.** This repo had *both* categories phpunit 14 removes.

## `with*()` without `expects()` — 6 sites

Every container configuration read:

```php
$this->container->method('has')->with('config')->willReturn(...);
```

In every case `$this->container` is a **genuine mock** — each of those tests also sets `expects()` on `get()` — so the fix is to give `has()` a real count rather than to drop the argument constraint. `atLeastOnce()` throughout, **verified by running** rather than assumed.

## Two doubles become stubs

- `WriterInterface` in `ConfigResourceFactoryTest` — property docblock moves from `MockObject` to `Stub`.
- `ModuleUtils` passed to the `ResourceFactory` constructor.

## `ConfigWriterFactoryTest` needed restructuring, not substitution

Its container was built in `setUp` and shared, but only **two of the four** tests configure it — the other two created a mock and never expected anything. Moving creation is the only fix, since **phpunit reports the notice against the creation, not the use**.

Each test now builds the double it actually needs: a **stub** where the factory merely receives a container, a **mock** where the test asserts on `has()` and `get()`. The shared property and the `MockObject` import go with it.

Behaviour is unchanged in those two tests — a stubbed `has()` returns `false` for a `bool` return type, exactly what the unconfigured mock returned.

## Result

29 tests / 88 assertions pass with **no issues at all** on 11.5.56 and 13.1.14, where 13 previously reported 6 deprecations and 7 notices. Baseline regenerated cold on 8.2 with the committed lock; psalm and phpcs clean.
